### PR TITLE
Add networkTimeout config for calls to coreUtil.fileUploadMeta

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Change the sampling interval, in microseconds. Defaults to 1000us.
 
 #### `debug` (bool: optional = false)
 
+#### `networkTimeout` (number: optional = 5000)
+
 Show debugging logs.
 
 ## Environment Variables

--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ Change the sampling interval, in microseconds. Defaults to 1000us.
 
 #### `debug` (bool: optional = false)
 
+Show debugging logs.
+
 #### `networkTimeout` (number: optional = 5000)
 
-Show debugging logs.
+Set timeout in ms for network requests.
 
 ## Environment Variables
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,8 @@ const defaultConfig = {
   sampleRate: 1000,
   enabled: false,
   heapSnapshot: false,
-  debug: false
+  debug: false,
+  networkTimeout: 5000
 };
 
 class ProfilerPlugin {
@@ -115,6 +116,7 @@ class ProfilerPlugin {
 
     return coreUtil.getFileUploadMeta({
       auth: this.token,
+      networkTimeout: this.config.networkTimeout,
       arn,
       requestId
     });


### PR DESCRIPTION
Allow consumers to override networkTimeout value for network requests at coreUtil.fileUploadMeta, and document. Default is 5000ms. See https://github.com/iopipe/iopipe-js-core/pull/307