### PR TITLE
Defers loading @iopipe/core until dependency cycles resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "aws-lambda-mock-context": "^3.2.1",
     "lodash": "^4.17.11",
     "nock": "^9.4.1",
-    "pre-commit": "^1.2.2"
+    "pre-commit": "^1.2.2",
+    "@iopipe/core": "^1.19.1"
   },
   "dependencies": {
-    "@iopipe/core": "^1.19.1",
     "archiver": "^2.1.1",
     "lodash.get": "^4.4.2",
     "simple-get": "^3.0.3"


### PR DESCRIPTION
Waits to require core's util so that dependency loading can be completed, and makes that conditional to avoid unnecessary loading.
Moves @iopipe/core to devDependencies
Closes #45
Closes #64